### PR TITLE
Use ROSControlItem

### DIFF
--- a/cnoid_tank_bringup/project/RTFPlant/Tank.cnoid
+++ b/cnoid_tank_bringup/project/RTFPlant/Tank.cnoid
@@ -1040,17 +1040,11 @@ items:
             - 
               id: 42
               name: "ROSControl"
-              plugin: Body
-              class: SimpleControllerItem
+              plugin: ROS
+              class: ROSControlItem
               isChecked: true
               data: 
-                isNoDelayMode: false
-                controllerOptions: ""
-                controller: "choreonoid_ros_control"
-                baseDirectory: "Controller directory"
-                reloading: false
-                exportSymbols: false
-                isOldTargetVariableMode: false
+                name_space: /Tank
 views: 
   - 
     id: 0

--- a/cnoid_tank_control/launch/control.launch
+++ b/cnoid_tank_control/launch/control.launch
@@ -4,7 +4,7 @@
   <param name="use_sim_time" value="true"/>
 
   <!-- robot description -->
-  <param name="/Tank/robot_description" command="$(find xacro)/xacro --inorder '$(arg model)'"/>
+  <param name="/Tank/robot_description" command="$(find xacro)/xacro '$(arg model)'"/>
    
   <!-- state publisher -->
   <node ns="Tank" name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true"/>

--- a/cnoid_tank_description/launch/display.launch
+++ b/cnoid_tank_description/launch/display.launch
@@ -4,7 +4,7 @@
   <arg name="gui" default="True" />
   <arg name="rviz_config" default="$(find cnoid_tank_description)/launch/config/display.rviz"/>
 
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(arg model)'"/>
+  <param name="robot_description" command="$(find xacro)/xacro '$(arg model)'"/>
 
   <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui"/>
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>

--- a/melodic.rosinstall
+++ b/melodic.rosinstall
@@ -7,10 +7,6 @@
     uri: https://github.com/choreonoid/choreonoid_ros.git
     version: master
 - git:
-    local-name: choreonoid_ros_control
-    uri: https://github.com/RyodoTanaka/choreonoid_ros_control.git
-    version: master
-- git:
     local-name: rtf-test-plant
     uri: https://github.com/choreonoid/rtf-test-plant.git
     version: master


### PR DESCRIPTION
This PR requires the Tank sample to use the latest choreonoid plugin for ros_control: currently the sample depends on choreonoid_ros_control, and the changed settings uses ROSControlItem, which is merged to ros_control from choreonoid_ros_control.

Additionally, this PR removes `--inorder` options of xacro, which was removed in ROS melodic.

This PR is expected to resolve #2 .